### PR TITLE
Changed 'path' to 'rendervar' in links and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ You'll need to download [Silex](http://silex.sensiolabs.org/) via [Composer](htt
   action. Check out `colorado.module.php` for examples of how alter-like hooks
   can affect builders.
 * Querystring parameters:
-  * `path` delegates the response to return JSON per an accessor-like syntax
+  * `rendervar` delegates the response to return JSON per an accessor-like syntax
     to represent the hierarchical tree of a given renderable. For example:
-    `/node/123?path=.` will return a JSON interpretation of the
-    renderable, while `/node/123?path=node.title` will just return the title
+    `/node/123?rendervar=.` will return a JSON interpretation of the
+    renderable, while `/node/123?rendervar=node.title` will just return the title
     of the node. (This does not yet distinguish sanitized variables).
-  * `themed` provided along with `path` processes the RenderableBuilder as a
+  * `themed` provided along with `rendervar` processes the RenderableBuilder as a
     Renderable preparing any relevant template variables per the final
     rendered state. For example: if a later preprocessor provides a `subtitle`
     variable to the node template, this can be available via
-    `/node/123?path=subtitle&themed=1`.
+    `/node/123?rendervar=subtitle&themed=1`.
 
 ## @todo
 

--- a/index.php
+++ b/index.php
@@ -190,8 +190,8 @@ $app->get('/', function(Request $request, Application $app) {
         RenderAPI::create('ThemeItemList', array(
         'items' => array(
           '<a href="' . $callback[0] . '">HTML</a>',
-          '<a href="' . $callback[0] . '?path=.">As JSON</a>',
-          '<a href="' . $callback[0] . '?path=.&themed=1">As JSON with template variables</a>',
+          '<a href="' . $callback[0] . '?rendervar=.">As JSON</a>',
+          '<a href="' . $callback[0] . '?rendervar=.&themed=1">As JSON with template variables</a>',
         ))),
       ));
   }


### PR DESCRIPTION
The index.php JSON examples weren't working for me.. I found base.php and realized you changed the param to be rendervar from path... I just changed the example links in index.html and readme.
